### PR TITLE
Move to alpine add ca-certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2019-06-09
+
+### Fixed
+- Turns out oauth requires `ca-certificates` package hence move to alpine
+
 ## [0.2.3] - 2019-06-09
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN go get .
 COPY . /app
 RUN CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' .
 
-FROM scratch
+FROM alpine:3.9.4
+RUN apk update && apk add ca-certificates
 WORKDIR /app
 COPY --from=build-env /app/auto-pocketer .
 CMD ["./auto-pocketer"]


### PR DESCRIPTION
Google's oauth was not working under bare `scratch` - turns out it has a
quasi-runtime dependency of ca-certificates being there.

This is fixed by moving to alpine and apk-adding those. The image is
22MB which is still very acceptable.